### PR TITLE
Fixes for PHP 8+ compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "kolesa-team/phalcon-clockwork",
   "description": "The clockwork extension for working with the phalcon framework",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "library",
   "authors": [
     {

--- a/src/DataSource/Base.php
+++ b/src/DataSource/Base.php
@@ -101,9 +101,9 @@ abstract class Base  extends DataSource implements InjectionAwareInterface
         $result = [];
 
         foreach ($data as $key => $item) {
-            if (is_array($item) & !method_exists($item, 'toArray')) {
+            if (is_array($item)) {
                 $item = $this->normalize($item);
-            } elseif (method_exists($item, 'toArray')) {
+            } elseif (is_object($item) && method_exists($item, 'toArray')) {
                 try {
                     $item = $item->toArray();
                 } catch (\Exception $e) {

--- a/src/Listeners/Base.php
+++ b/src/Listeners/Base.php
@@ -11,7 +11,7 @@ abstract class Base extends Injectable
     /**
      * Get cloсkwork
      *
-     * @return \Kolesa\Clockwork\ClockworkSupport
+     * @return \Clockwork\Clockwork
      */
     protected function getClockwork()
     {

--- a/src/Storage/Memcached.php
+++ b/src/Storage/Memcached.php
@@ -24,6 +24,13 @@ class Memcached extends Storage
     const KEY_HASH_STORED = 'Clockwork:Storage';
 
     /**
+     * Storage options
+     *
+     * @var array|\Phalcon\Config\Config
+     */
+    protected $options;
+
+    /**
      * Memcached client
      *
      * @var \Memcached

--- a/src/Storage/Redis.php
+++ b/src/Storage/Redis.php
@@ -24,6 +24,13 @@ class Redis extends Storage
     const KEY_HASH_STORED = 'Clockwork:Storage';
 
     /**
+     * Storage options
+     *
+     * @var array|\Phalcon\Config\Config
+     */
+    protected $options;
+
+    /**
      * Redis client
      *
      * @var \Redis


### PR DESCRIPTION
- `method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given`
- `Creation of dynamic property Kolesa\Clockwork\Storage\Redis::$options is deprecated`