### PR TITLE
Redis storage fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "kolesa-team/phalcon-clockwork",
   "description": "The clockwork extension for working with the phalcon framework",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "library",
   "authors": [
     {

--- a/src/Storage/Redis.php
+++ b/src/Storage/Redis.php
@@ -194,7 +194,7 @@ class Redis extends Storage
         $data   = $this->getClient()->hMGet(self::KEY_HASH_STORED, $ids);
 
         foreach ($data as $value) {
-            $result[] = new Request(json_decode($value, true));
+            $result[] = new Request(json_decode($value, true) ?: []);
         }
 
         return $result;
@@ -210,7 +210,7 @@ class Redis extends Storage
         $options = $this->options;
         $host    = $options['host'] ?? null;
         $port    = $options['port'] ?? null;
-        $timeout = $options['timeout'] ?? null;
+        $timeout = $options['timeout'] ?? 0; // default is 0 meaning it will use default_socket_timeout
 
         if ($host === null) {
             throw new \Exception('Unexpected inconsistency in options');


### PR DESCRIPTION
- `Redis::connect(): Passing null to parameter #3 ($timeout) of type float is deprecated`
- `Clockwork\Request\Request::__construct(): Argument #1 ($data) must be of type array, null given`